### PR TITLE
fix: Correct f-string syntax in admin cog

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -92,7 +92,9 @@ class AdminCog(commands.Cog, name="Admin"):
             message += f"- Branch: `{branch}`\n"
             message += f"- Commit: `{commit_hash}`\n"
             if tags:
-                message += f"- Tags: `{tags.replace('\\n', ', ')}`"
+                # Replace actual newline characters from git output with ", " for display
+                tags_formatted = tags.replace('\n', ', ')
+                message += f"- Tags: `{tags_formatted}`"
             else:
                 message += "- Tags: `No tags on current commit.`"
 


### PR DESCRIPTION
- Resolved an f-string syntax error in cogs/admin.py related to backslashes within an expression placeholder when formatting git tags for display.
- The tags string is now processed to replace newline characters before being included in the f-string.